### PR TITLE
Close panel shortcut #13

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ## Requirements
 
-* You need py.test installed to use this package: 
+* You need py.test installed to use this package:
 
     ```
     pip install pytest
@@ -22,6 +22,8 @@ When using virtualenv, the recommended workflow is:
 1) Running all tests ```(Ctrl + Alt + T)```
 
 2) Run test under cursor ```(Ctrl + Alt + C)```
+
+3) Hide the execution panel ```(Ctrl + Alt + H)```
 
 ![Run tests](https://cloud.githubusercontent.com/assets/1611808/14330216/ea1891e0-fc15-11e5-8190-696152c77c64.gif)
 

--- a/keymaps/atom-python-test.cson
+++ b/keymaps/atom-python-test.cson
@@ -10,3 +10,4 @@
 'atom-workspace':
   'ctrl-alt-t': 'atom-python-test:run-all-tests'
   'ctrl-alt-c': 'atom-python-test:run-test-under-cursor'
+  'ctrl-alt-h': 'atom-python-test:close-panel'

--- a/lib/atom-python-test.coffee
+++ b/lib/atom-python-test.coffee
@@ -29,6 +29,7 @@ module.exports = AtomPythonTest =
     # Register command that toggles this view
     @subscriptions.add atom.commands.add 'atom-workspace', 'atom-python-test:run-all-tests': => @runAllTests()
     @subscriptions.add atom.commands.add 'atom-workspace', 'atom-python-test:run-test-under-cursor': => @runTestUnderCursor()
+    @subscriptions.add atom.commands.add 'atom-workspace', 'atom-python-test:close-panel': => @closePanel()
 
   deactivate: ->
     @subscriptions.dispose()
@@ -122,3 +123,6 @@ module.exports = AtomPythonTest =
     file = editor?.buffer.file
     filePath = file?.path
     @executePyTest(filePath)
+
+  closePanel: ->
+      @atomPythonTestView.destroy()

--- a/menus/atom-python-test.cson
+++ b/menus/atom-python-test.cson
@@ -12,6 +12,10 @@
           'label': 'Run all tests'
           'command': 'atom-python-test:run-all-tests'
         }
+        {
+          'label': 'Close panel'
+          'command': 'atom-python-test:close-panel'
+        }
       ]
     }
   ]
@@ -24,6 +28,10 @@
         {
           'label': 'Run all tests'
           'command': 'atom-python-test:run-all-tests'
+        }
+        {
+          'label': 'Close panel'
+          'command': 'atom-python-test:close-panel'
         }
       ]
     ]


### PR DESCRIPTION
Press (ctrl + alt + h) to hide the output panel.